### PR TITLE
chore: limit github-actions dependabot to react-doctor only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,8 @@ updates:
       day: monday
       time: "09:00"
       timezone: Asia/Tokyo
+    allow:
+      - dependency-name: "millionco/react-doctor"
     assignees:
       - yuzuki0371
     labels:


### PR DESCRIPTION
## Summary

- `github-actions` エコシステムの Dependabot 更新対象を `millionco/react-doctor` のみに限定
- `actions/checkout`、`pnpm/action-setup`、`actions/setup-node` は自動更新PRの対象外になる

## Test plan

- [x] `dependabot.yml` の `github-actions` セクションに `allow: millionco/react-doctor` が追加されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)